### PR TITLE
Void order online when canceling order

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,6 +10,7 @@
                 <can_order>1</can_order>
                 <can_capture>1</can_capture>
                 <can_refund>1</can_refund>
+                <can_cancel>1</can_cancel>
                 <can_void>1</can_void>
                 <partial_refund>1</partial_refund>
                 <can_use_checkout>1</can_use_checkout>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -39,6 +39,7 @@
                 <item name="capture" xsi:type="string">DibsFlexwinCaptureGatewayCommand</item>
                 <item name="refund" xsi:type="string">DibsFlexwinRefundGatewayCommand</item>
                 <item name="void" xsi:type="string">DibsFlexwinVoidGatewayCommand</item>
+                <item name="cancel" xsi:type="string">DibsFlexwinVoidGatewayCommand</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
When admin cancels order in Magento, it should also cancel online. Please review this pull request.

I consulted stock Magento 2 EE modules as to how they handle void vs cancelation and found that reusing same command is acceptable.
E.g. Magento_Braintree:
```
<item name="void" xsi:type="string">BraintreeVoidCommand</item>
...
<item name="cancel" xsi:type="string">BraintreeVoidCommand</item>
```

Alternative approach to hardcoding can_cancel can be found in Magento_Cybersource:
```
    <virtualType name="CybersourceValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
        <arguments>
            <argument name="handlers" xsi:type="array">
                <item name="default" xsi:type="string">CybersourceDefaultValueHandler</item>
                <item name="can_void" xsi:type="string">Magento\Cybersource\Gateway\Config\CanVoidHandler</item>
                <item name="can_cancel" xsi:type="string">Magento\Cybersource\Gateway\Config\CanVoidHandler</item>
            </argument>
        </arguments>
    </virtualType>
```
It allows voiding when paid amount is positive:
```
return !$payment instanceof Payment || !(bool)$payment->getAmountPaid();
```
But we should still be find with current solution.