### PR TITLE
Magento 2.2 fix

### DIFF
--- a/Model/Config/Backend/Makeinvoice.php
+++ b/Model/Config/Backend/Makeinvoice.php
@@ -3,15 +3,26 @@
  * Copyright © 2015 Magento. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Dibs\Flexwin\Model\Config\Backend;
 
+/**
+ * Class Makeinvoice
+ * @package Dibs\Flexwin\Model\Config\Backend
+ */
 class Makeinvoice extends \Magento\Framework\App\Config\Value
 {
+    /**
+     * @var
+     */
     protected $requestData;
 
+    /**
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
     public function beforeSave()
     {
-        if($this->getFieldsetDataValue('capturenow') == 0 && $this->getValue() == 1) {
+        if (0 === $this->getFieldsetDataValue('capturenow') && 1 == $this->getValue()) {
             $field = $this->getFieldConfig();
             $label = $field && is_array($field) ? $field['label'] : 'value';
             $msg = __('Invalid %1. %2', $label, 'For enabling this feature, \'Capturenow\' must be enabled');
@@ -19,5 +30,4 @@ class Makeinvoice extends \Magento\Framework\App\Config\Value
         }
 
     }
-
 }


### PR DESCRIPTION
On Magento 2.2 during setup:upgrade or app:config:import 
$this->getFieldsetDataValue('capturenow') was returning null.

Because of that exception was being thrown causing cli script to fail.